### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xanitizer-analysis.yml
+++ b/.github/workflows/xanitizer-analysis.yml
@@ -41,6 +41,8 @@ jobs:
   xanitizer-security-analysis:
     # Xanitizer runs on ubuntu-latest and windows-latest.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       # Check out the repository


### PR DESCRIPTION
Potential fix for [https://github.com/anoraktrend/kinlandweb/security/code-scanning/1](https://github.com/anoraktrend/kinlandweb/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this workflow, the steps read repository contents and upload artifacts and SARIF files, but they do not need to write to repository contents, issues, or pull requests. The minimal and appropriate scope is `contents: read` (other actions like `upload-artifact` and `upload-sarif` work with the token they receive and do not require extra repository write scopes).

The best fix without changing existing functionality is to add a `permissions:` block at the job level, directly under `runs-on: ubuntu-latest` for the `xanitizer-security-analysis` job. This keeps the change local to this workflow and clearly documents that the job only needs read access to repository contents. Concretely, in `.github/workflows/xanitizer-analysis.yml`, after line 43 (`runs-on: ubuntu-latest`), add:

```yaml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are needed because this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
